### PR TITLE
Expose red/blue gains in PicamJNI

### DIFF
--- a/PicamJNI.cpp
+++ b/PicamJNI.cpp
@@ -412,6 +412,26 @@ Java_org_photonvision_raspi_PicamJNI_setGain(JNIEnv *, jclass, jint gain) {
                                    gain / 100.0 * 8.0);
 }
 
+// These gains should be between 0.0 and 8.0, and can be a float
+JNIEXPORT jboolean JNICALL
+Java_org_photonvision_raspi_PicamJNI_setAWB(JNIEnv *, jclass, jfloat redGain, jfloat blueGain) {
+  if (!mmal_state.camera)
+    return true;
+
+  // Clamp to [0.0, 8.0]
+  // TODO do we want to warn the user when clamping?
+  redGain = fmax(redGain, 0);
+  redGain = fmin(redGain, 8);
+  blueGain = fmax(blueGain, 0);
+  blueGain = fmin(blueGain, 8);
+
+  // AWB must be off to set our gains
+  // It should be off my default, but we should make sure regardless
+  int ret = raspicamcontrol_set_awb_mode(mmal_state.camera, MMAL_PARAM_AWBMODE_OFF);
+  ret |= raspicamcontrol_set_awb_gains(mmal_state.camera, redGain, blueGain);
+  return ret;
+}
+
 JNIEXPORT jboolean JNICALL Java_org_photonvision_raspi_PicamJNI_setRotation(
     JNIEnv *, jclass, jint rotationOrdinal) {
   int rotation = (rotationOrdinal + 3) * 90; // Degrees

--- a/RaspiCamControl.c
+++ b/RaspiCamControl.c
@@ -64,8 +64,9 @@ void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params) {
   params->roi.x = params->roi.y = 0.0;
   params->roi.w = params->roi.h = 1.0;
   params->shutter_speed = 0; // 0 = auto
-  params->awb_gains_r = 1;   // Only have any function if AWB OFF is used.
-  params->awb_gains_b = 1;
+  // These default gains seem reasonable for short exposure times
+  params->awb_gains_r = 1.975;   // Only have any function if AWB OFF is used.
+  params->awb_gains_b = 1.200;
   params->drc_level = MMAL_PARAMETER_DRC_STRENGTH_OFF;
   params->stats_pass = MMAL_FALSE;
   params->enable_annotate = 0;


### PR DESCRIPTION
Allows red/blue gains to be set manually, rather than fixed at startup.